### PR TITLE
fix: temporarily not creating plugin setting

### DIFF
--- a/addons/ninetailsrabbit.lootie/ninetailsrabbit.lootie.gd
+++ b/addons/ninetailsrabbit.lootie/ninetailsrabbit.lootie.gd
@@ -6,7 +6,7 @@ const UpdateNotifyToolScene = preload("updater/update_notify_tool.tscn")
 var update_notify_tool_instance: Node
 
 func _enter_tree() -> void:
-	MyPluginSettings.set_update_notification()
+	#MyPluginSettings.set_update_notification()
 	_setup_updater()
 	
 	if not DirAccess.dir_exists_absolute(MyPluginSettings.PluginTemporaryReleaseUpdateDirectoryPath):
@@ -23,7 +23,7 @@ func _enter_tree() -> void:
 	
 
 func _exit_tree() -> void:
-	MyPluginSettings.remove_settings()
+	#MyPluginSettings.remove_settings()
 	
 	if update_notify_tool_instance:
 		update_notify_tool_instance.free()


### PR DESCRIPTION
The setting creation/deletion makes godot remove autoloads and add then back in the wrong order, next time.

## Description

Add your description here, especially why you made these changes and what problem you tried to solve.

## Addressed issues

- List issues here, reference them via #

## Screenshots (Optional)

Show your changes with screenshots
